### PR TITLE
AB#108138 enable sw fallback

### DIFF
--- a/android/contrib/tools/do-detect-env.sh
+++ b/android/contrib/tools/do-detect-env.sh
@@ -88,7 +88,9 @@ esac
 
 case "$UNAME_S" in
     Darwin)
-        export IJK_MAKE_FLAG=-j`sysctl -n machdep.cpu.thread_count`
+        # Forcing only 1 thread due to build error on MacOS which was caused becasue of multithreading
+        # More details here: https://github.com/bilibili/ijkplayer/issues/5113#issuecomment-1288378800
+        export IJK_MAKE_FLAG=-j1
     ;;
     CYGWIN_NT-*)
         IJK_WIN_TEMP="$(cygpath -am /tmp)"

--- a/ijkmedia/ijkplayer/android/pipeline/ffpipeline_android.c
+++ b/ijkmedia/ijkplayer/android/pipeline/ffpipeline_android.c
@@ -70,9 +70,12 @@ static IJKFF_Pipenode *func_open_video_decoder(IJKFF_Pipeline *pipeline, FFPlaye
     IJKFF_Pipeline_Opaque *opaque = pipeline->opaque;
     IJKFF_Pipenode        *node = NULL;
 
-    if (ffp->mediacodec_all_videos || ffp->mediacodec_avc || ffp->mediacodec_hevc || ffp->mediacodec_mpeg2)
+    if (ffp->mediacodec_all_videos || ffp->mediacodec_avc || ffp->mediacodec_hevc || ffp->mediacodec_mpeg2) {
+        ALOGI("Creating mediacodec video decoder.");
         node = ffpipenode_create_video_decoder_from_android_mediacodec(ffp, pipeline, opaque->weak_vout);
+    }
     if (!node) {
+        ALOGI("Cannot create mediacodec video decoder, falling back to ffmpeg");
         node = ffpipenode_create_video_decoder_from_ffplay(ffp);
     }
 

--- a/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
+++ b/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
@@ -2060,7 +2060,6 @@ IJKFF_Pipenode *ffpipenode_create_video_decoder_from_android_mediacodec(FFPlayer
     }
 
     jsurface = ffpipeline_get_surface_as_global_ref(env, pipeline);
-
     ret = configure_codec_l(env, node, jsurface);
     J4A_DeleteGlobalRef__p(env, &jsurface);
     if (ret != 0)

--- a/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
+++ b/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
@@ -2060,7 +2060,8 @@ IJKFF_Pipenode *ffpipenode_create_video_decoder_from_android_mediacodec(FFPlayer
     }
 
     jsurface = ffpipeline_get_surface_as_global_ref(env, pipeline);
-    ret = reconfigure_codec_l(env, node, jsurface);
+
+    ret = configure_codec_l(env, node, jsurface);
     J4A_DeleteGlobalRef__p(env, &jsurface);
     if (ret != 0)
         goto fail;

--- a/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
+++ b/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
@@ -2060,6 +2060,8 @@ IJKFF_Pipenode *ffpipenode_create_video_decoder_from_android_mediacodec(FFPlayer
     }
 
     jsurface = ffpipeline_get_surface_as_global_ref(env, pipeline);
+    // Not calling reconfigure because don't want to stop non-started codec in order to 
+    // reassign the surface
     ret = configure_codec_l(env, node, jsurface);
     J4A_DeleteGlobalRef__p(env, &jsurface);
     if (ret != 0)


### PR DESCRIPTION
Enable SW fallback

**Issue**

Calling to **reconfigure_codec**  we are stopping/starting a fresh created mediacodec in order to reassign the surface. This process is not working on RSplus and also is not needed for our use case since we are using one player for each stream so we change the method used to use configure_codec that is not stoping the decoder. 

**Tests**

Working fine on all targets that includes:

- SMART Moose scaler
- Dell TPV D7523QT
- QSeries
- NT
- RSplus